### PR TITLE
JG-26 - [FE] Refactor Standard React Arrow/Function Component

### DIFF
--- a/frontend/src/components/molecules/blog-card/index.tsx
+++ b/frontend/src/components/molecules/blog-card/index.tsx
@@ -1,18 +1,18 @@
+import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import React, { FC } from 'react'
 import { ChevronRight } from 'lucide-react'
 
 import { cn } from '~/utils/cn'
 import { Blog } from '~/utils/types'
 import { Badge } from '~/components/atoms/badge'
 
-type Props = {
+type BlogCardProps = {
   blog: Blog
   idx: number
 }
 
-const BlogCard: FC<Props> = ({ blog, idx }): JSX.Element => {
+export const BlogCard = ({ blog, idx }: BlogCardProps): JSX.Element => {
   const index = idx + 1
   return (
     <div
@@ -60,5 +60,3 @@ const BlogCard: FC<Props> = ({ blog, idx }): JSX.Element => {
     </div>
   )
 }
-
-export default BlogCard

--- a/frontend/src/components/molecules/experience-timeline/index.tsx
+++ b/frontend/src/components/molecules/experience-timeline/index.tsx
@@ -1,14 +1,14 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { cn } from '~/utils/cn'
 import { nunito } from '~/utils/font'
 import { Experience } from '~/utils/constant/experiences'
 
-type Props = {
+type ExperienceTimeLineProps = {
   exp: Experience
 }
 
-const ExperienceTimeLine: FC<Props> = ({ exp }): JSX.Element => {
+export const ExperienceTimeLine = ({ exp }: ExperienceTimeLineProps): JSX.Element => {
   return (
     <div
       className="relative mt-16 flex items-start gap-x-6 sm:gap-x-12 md:gap-x-24"
@@ -52,5 +52,3 @@ const ExperienceTimeLine: FC<Props> = ({ exp }): JSX.Element => {
     </div>
   )
 }
-
-export default ExperienceTimeLine

--- a/frontend/src/components/molecules/nav-popover/NavPopover.tsx
+++ b/frontend/src/components/molecules/nav-popover/NavPopover.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { Menu } from 'lucide-react'
 import { Link as ScrollLink } from 'react-scroll'
 
@@ -6,13 +6,15 @@ import { TLink } from '~/utils/types'
 import { Button } from '~/components/atoms/button'
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/templates/popover'
 
-type Props = {
+type NavPopoverProps = {
   links: TLink[]
   activeNav: number | null
   handleOnSetActive: (link: TLink) => void
 }
 
-const NavPopover: FC<Props> = ({ links, activeNav, handleOnSetActive }): JSX.Element => {
+export const NavPopover = (props: NavPopoverProps): JSX.Element => {
+  const { links, activeNav, handleOnSetActive } = props
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -58,5 +60,3 @@ const NavPopover: FC<Props> = ({ links, activeNav, handleOnSetActive }): JSX.Ele
     </Popover>
   )
 }
-
-export default NavPopover

--- a/frontend/src/components/molecules/project-card/index.tsx
+++ b/frontend/src/components/molecules/project-card/index.tsx
@@ -1,5 +1,5 @@
+import React from 'react'
 import Image from 'next/image'
-import React, { FC } from 'react'
 import { Github, Link, Star } from 'lucide-react'
 
 import { cn } from '~/utils/cn'
@@ -10,11 +10,11 @@ import { IProject } from '~/utils/constant/my-projects'
 import useScreenCondition from '~/hooks/useScreenCondition'
 import { Card, CardContent, CardTitle } from '~/components/atoms/card'
 
-type Props = {
+type ProjectCardProps = {
   project: IProject
 }
 
-const ProjectCard: FC<Props> = ({ project }): JSX.Element => {
+export const ProjectCard = ({ project }: ProjectCardProps): JSX.Element => {
   const { title, description, demoUrl, imageUrl, rating, sourceCodeUrl, tags } = project
 
   const isMediumScreen = useScreenCondition('(max-width: 768px)')
@@ -74,5 +74,3 @@ const ProjectCard: FC<Props> = ({ project }): JSX.Element => {
     </Card>
   )
 }
-
-export default ProjectCard

--- a/frontend/src/components/molecules/section-title/index.tsx
+++ b/frontend/src/components/molecules/section-title/index.tsx
@@ -1,14 +1,14 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { cn } from '~/utils/cn'
 import { nunito } from '~/utils/font'
-import BubbleCircleIcon from '~/utils/icons/BubbleCircleIcon'
+import { BubbleCircleIcon } from '~/utils/icons/BubbleCircleIcon'
 
-type Props = {
+type SectionTitleProps = {
   title: string
 }
 
-const SectionTitle: FC<Props> = ({ title }): JSX.Element => {
+export const SectionTitle = ({ title }: SectionTitleProps): JSX.Element => {
   return (
     <div className="relative">
       <h2 className={cn('h2', nunito.className)}>{title}</h2>
@@ -16,5 +16,3 @@ const SectionTitle: FC<Props> = ({ title }): JSX.Element => {
     </div>
   )
 }
-
-export default SectionTitle

--- a/frontend/src/components/molecules/skill-card/index.tsx
+++ b/frontend/src/components/molecules/skill-card/index.tsx
@@ -1,10 +1,10 @@
+import React from 'react'
 import Image from 'next/image'
-import React, { FC } from 'react'
 
 import { cn } from '~/utils/cn'
 import { Skill } from '~/utils/constant/my-skills'
 
-const SkillCard: FC<Skill> = ({ title, image }): JSX.Element => {
+export const SkillCard = ({ title, image }: Skill): JSX.Element => {
   return (
     <div
       className={cn(
@@ -29,5 +29,3 @@ const SkillCard: FC<Skill> = ({ title, image }): JSX.Element => {
     </div>
   )
 }
-
-export default SkillCard

--- a/frontend/src/components/molecules/testimonial-card/index.tsx
+++ b/frontend/src/components/molecules/testimonial-card/index.tsx
@@ -1,16 +1,16 @@
+import React from 'react'
 import Image from 'next/image'
-import React, { FC } from 'react'
 
 import { cn } from '~/utils/cn'
 import { oleoScript } from '~/utils/font'
 import { Card } from '~/components/atoms/card'
 import { Testimony } from '~/utils/constant/testimonials'
 
-type Props = {
+type TestimonialCardProps = {
   testimony: Testimony
 }
 
-const TestimonialCard: FC<Props> = ({ testimony }): JSX.Element => {
+export const TestimonialCard = ({ testimony }: TestimonialCardProps): JSX.Element => {
   return (
     <Card className="relative mx-auto flex w-full max-w-3xl flex-col items-center justify-center overflow-visible rounded-[40px] dark:bg-slate-900">
       <p
@@ -46,5 +46,3 @@ const TestimonialCard: FC<Props> = ({ testimony }): JSX.Element => {
     </Card>
   )
 }
-
-export default TestimonialCard

--- a/frontend/src/components/organisms/footer/index.tsx
+++ b/frontend/src/components/organisms/footer/index.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { Facebook, Linkedin } from 'lucide-react'
 
 import { cn } from '~/utils/cn'
 import { nunito } from '~/utils/font'
 
-const Footer: FC<Record<string, unknown>> = (): JSX.Element => {
+export const Footer = (): JSX.Element => {
   return (
     <footer data-aos="fade-up" data-aos-offset="0" className="mb-14">
       <div className="mx-auto w-full max-w-6xl px-4">
@@ -43,5 +43,3 @@ const Footer: FC<Record<string, unknown>> = (): JSX.Element => {
     </footer>
   )
 }
-
-export default Footer

--- a/frontend/src/components/organisms/header/index.tsx
+++ b/frontend/src/components/organisms/header/index.tsx
@@ -1,20 +1,20 @@
 import { useTheme } from 'next-themes'
 import { Link as ScrollLink } from 'react-scroll'
+import React, { useEffect, useState } from 'react'
 import DarkModeToggle from 'react-dark-mode-toggle'
-import React, { FC, useEffect, useState } from 'react'
 
 import { cn } from '~/utils/cn'
 import { TLink } from '~/utils/types'
 import { Button } from '~/components/atoms/button'
 import { LogoTitle } from '~/components/atoms/logo-title'
 import useScreenCondition from '~/hooks/useScreenCondition'
-import NavPopover from '~/components/molecules/nav-popover/NavPopover'
+import { NavPopover } from '~/components/molecules/nav-popover/NavPopover'
 
-type Props = {
+type HeaderProps = {
   links: TLink[]
 }
 
-const Header: FC<Props> = ({ links }): JSX.Element => {
+export const Header = ({ links }: HeaderProps): JSX.Element => {
   const { theme, setTheme } = useTheme()
   const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
@@ -117,5 +117,3 @@ const Header: FC<Props> = ({ links }): JSX.Element => {
     </div>
   )
 }
-
-export default Header

--- a/frontend/src/components/templates/about-section/index.tsx
+++ b/frontend/src/components/templates/about-section/index.tsx
@@ -1,9 +1,9 @@
+import React from 'react'
 import Image from 'next/image'
-import React, { FC } from 'react'
 
-import SectionTitle from '~/components/molecules/section-title'
+import { SectionTitle } from '~/components/molecules/section-title'
 
-const AboutSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function AboutSection(): JSX.Element {
   return (
     <section id="about" className="section">
       <div className="grid grid-cols-1 gap-x-8 md:grid-cols-2">
@@ -38,5 +38,3 @@ const AboutSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default AboutSection

--- a/frontend/src/components/templates/blog-layout/index.tsx
+++ b/frontend/src/components/templates/blog-layout/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { useTheme } from 'next-themes'
 import DarkModeToggle from 'react-dark-mode-toggle'
-import React, { FC, ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useEffect, useState } from 'react'
 
 import { cn } from '~/utils/cn'
 import Layout from './../layout'
@@ -12,14 +12,16 @@ import { Button } from '~/components/atoms/button'
 import ScrollProgress from '~/lib/scroll-progress'
 import { LogoTitle } from '~/components/atoms/logo-title'
 
-type Props = {
+type BlogLayoutProps = {
   title: string
   publishedAt: string
   readTime: number
   children: ReactNode
 }
 
-const BlogLayout: FC<Props> = ({ title, publishedAt, readTime, children }): JSX.Element => {
+export default function BlogLayout(props: BlogLayoutProps): JSX.Element {
+  const { title, publishedAt, readTime, children } = props
+
   const [header, setHeader] = useState<boolean>(false)
   const [links] = useState<TLink[]>([
     {
@@ -126,5 +128,3 @@ const BlogLayout: FC<Props> = ({ title, publishedAt, readTime, children }): JSX.
     </Layout>
   )
 }
-
-export default BlogLayout

--- a/frontend/src/components/templates/blog-section/index.tsx
+++ b/frontend/src/components/templates/blog-section/index.tsx
@@ -1,16 +1,16 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { Blog } from '~/utils/types'
 import { Button } from '~/components/atoms/button'
-import BlogCard from '~/components/molecules/blog-card'
+import { BlogCard } from '~/components/molecules/blog-card'
 import useScreenCondition from '~/hooks/useScreenCondition'
-import SectionTitle from '~/components/molecules/section-title'
+import { SectionTitle } from '~/components/molecules/section-title'
 
-type Props = {
+type BlogSectionProps = {
   posts: Blog[]
 }
 
-const BlogSection: FC<Props> = ({ posts }): JSX.Element => {
+export default function BlogSection({ posts }: BlogSectionProps): JSX.Element {
   const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
   return (
@@ -44,5 +44,3 @@ const BlogSection: FC<Props> = ({ posts }): JSX.Element => {
     </section>
   )
 }
-
-export default BlogSection

--- a/frontend/src/components/templates/contact-section/index.tsx
+++ b/frontend/src/components/templates/contact-section/index.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { cn } from '~/utils/cn'
 import { Button } from '~/components/atoms/button'
-import SectionTitle from '~/components/molecules/section-title'
+import { SectionTitle } from '~/components/molecules/section-title'
 
-const ContactSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function ContactSection(): JSX.Element {
   return (
     <section id="contact" className="mx-auto w-full max-w-6xl px-4 py-16">
       <div
@@ -70,5 +70,3 @@ const ContactSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default ContactSection

--- a/frontend/src/components/templates/experience-section/index.tsx
+++ b/frontend/src/components/templates/experience-section/index.tsx
@@ -1,10 +1,10 @@
-import React, { FC, useState } from 'react'
+import React, { useState } from 'react'
 
 import { experiences } from '~/utils/constant/experiences'
-import SectionTitle from '~/components/molecules/section-title'
-import ExperienceTimeLine from '~/components/molecules/experience-timeline'
+import { SectionTitle } from '~/components/molecules/section-title'
+import { ExperienceTimeLine } from '~/components/molecules/experience-timeline'
 
-const ExperienceSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function ExperienceSection(): JSX.Element {
   const [showAllExperiences, setShowAllExperiences] = useState(true)
 
   const visibleExperiences = showAllExperiences ? experiences : experiences.slice(0, 2)
@@ -40,5 +40,3 @@ const ExperienceSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default ExperienceSection

--- a/frontend/src/components/templates/hero-section/index.tsx
+++ b/frontend/src/components/templates/hero-section/index.tsx
@@ -1,21 +1,21 @@
 import Image from 'next/image'
 import CountUp from 'react-countup'
-import React, { FC, useState } from 'react'
+import React, { useState } from 'react'
 import { ArrowUp, Plus } from 'lucide-react'
 
 import { cn } from '~/utils/cn'
 import { TLink } from '~/utils/types'
 import { nunito } from '~/utils/font'
 import { Card } from '~/components/atoms/card'
-import TropyIcon from '~/utils/icons/TropyIcon'
-import FigmaIcon from '~/utils/icons/FigmaIcon'
-import NextJSIcon from '~/utils/icons/NextJSIcon'
 import { Button } from '~/components/atoms/button'
-import Header from '~/components/organisms/header'
-import TailwindcssIcon from '~/utils/icons/TailwindcssIcon'
-import BubbleCircleIcon from '~/utils/icons/BubbleCircleIcon'
+import { TropyIcon } from '~/utils/icons/TropyIcon'
+import { FigmaIcon } from '~/utils/icons/FigmaIcon'
+import { NextJSIcon } from '~/utils/icons/NextJSIcon'
+import { Header } from '~/components/organisms/header'
+import { TailwindcssIcon } from '~/utils/icons/TailwindcssIcon'
+import { BubbleCircleIcon } from '~/utils/icons/BubbleCircleIcon'
 
-const HeroSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function HeroSection(): JSX.Element {
   const [links] = useState<TLink[]>([
     {
       text: 'Home',
@@ -106,7 +106,7 @@ const HeroSection: FC<Record<string, unknown>> = (): JSX.Element => {
           <div
             className={cn(
               'absolute -right-[80px] -top-[750px] z-10 rotate-[38deg]',
-              'scale-75 sm:-right-[150px] sm:-top-[1000px] sm:scale-125'
+              'scale-75 sm:-right-[150px] sm:-top-[1050px] sm:scale-125'
             )}
           >
             <Image
@@ -141,7 +141,7 @@ function TailwindIconComp(): JSX.Element {
     <div
       className={cn(
         'absolute bottom-[220px] right-[250px] z-10 rounded-full p-2.5',
-        'shadow-md dark:bg-slate-800 sm:bottom-[220px] sm:right-[450px]',
+        'shadow-md dark:bg-slate-800 sm:bottom-[220px] sm:right-[470px]',
         'transition-colors duration-700'
       )}
     >
@@ -155,7 +155,7 @@ function NextJSIconComp(): JSX.Element {
     <div>
       <NextJSIcon
         className={cn(
-          'absolute bottom-[210px] right-[30px] z-10 h-20',
+          'absolute bottom-[250px] right-[30px] z-10 h-20',
           'w-20 scale-75 text-black sm:right-[80px] sm:scale-100'
         )}
       />
@@ -167,7 +167,7 @@ function FigmaIconComp(): JSX.Element {
   return (
     <div
       className={cn(
-        'absolute bottom-[80px] right-[40px] z-10 rounded-full',
+        'absolute bottom-[90px] right-[40px] z-10 rounded-full',
         'bg-slate-200 p-2.5 shadow-md dark:bg-slate-800',
         'transition-colors duration-700'
       )}
@@ -223,5 +223,3 @@ function ProjectNumberCardComp(): JSX.Element {
     </div>
   )
 }
-
-export default HeroSection

--- a/frontend/src/components/templates/layout/index.tsx
+++ b/frontend/src/components/templates/layout/index.tsx
@@ -1,14 +1,14 @@
 import Head from 'next/head'
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode } from 'react'
 
 import { cn } from '~/utils/cn'
 
-type Props = {
+type LayoutProps = {
   metaTitle?: string
   children: ReactNode
 }
 
-const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
+export default function Layout({ metaTitle, children }: LayoutProps): JSX.Element {
   return (
     <div
       className={cn('overflow-hidden bg-white transition-colors', 'duration-700 dark:bg-slate-900')}
@@ -26,5 +26,3 @@ const Layout: FC<Props> = ({ metaTitle, children }): JSX.Element => {
     </div>
   )
 }
-
-export default Layout

--- a/frontend/src/components/templates/my-skills-section/index.tsx
+++ b/frontend/src/components/templates/my-skills-section/index.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { myskills } from '~/utils/constant/my-skills'
-import SkillCard from '~/components/molecules/skill-card'
-import SectionTitle from '~/components/molecules/section-title'
+import { SkillCard } from '~/components/molecules/skill-card'
+import { SectionTitle } from '~/components/molecules/section-title'
 
-const MySkillsSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function MySkillsSection(): JSX.Element {
   return (
     <section id="my-skills" className="section">
       {/* Title */}
@@ -28,5 +28,3 @@ const MySkillsSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default MySkillsSection

--- a/frontend/src/components/templates/projects-section/index.tsx
+++ b/frontend/src/components/templates/projects-section/index.tsx
@@ -1,13 +1,13 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { EffectCoverflow, Pagination } from 'swiper/modules'
 
 import { myProjects } from '~/utils/constant/my-projects'
 import useScreenCondition from '~/hooks/useScreenCondition'
-import ProjectCard from '~/components/molecules/project-card'
-import SectionTitle from '~/components/molecules/section-title'
+import { ProjectCard } from '~/components/molecules/project-card'
+import { SectionTitle } from '~/components/molecules/section-title'
 
-const ProjectsSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function ProjectsSection(): JSX.Element {
   const isMediumScreen = useScreenCondition('(max-width: 768px)')
 
   return (
@@ -47,5 +47,3 @@ const ProjectsSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default ProjectsSection

--- a/frontend/src/components/templates/social-link-section/index.tsx
+++ b/frontend/src/components/templates/social-link-section/index.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from 'react'
+import React from 'react'
 
 import { cn } from '~/utils/cn'
 import { socialLinks } from '~/utils/constant/socialLinks'
 
-const SocialLinkSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function SocialLinkSection(): JSX.Element {
   return (
     <section
       className="section mt-24 grid grid-cols-2 gap-4 px-4 py-4 sm:mt-8 sm:grid-cols-4"
@@ -26,5 +26,3 @@ const SocialLinkSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default SocialLinkSection

--- a/frontend/src/components/templates/testimonial-section/index.tsx
+++ b/frontend/src/components/templates/testimonial-section/index.tsx
@@ -1,12 +1,12 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Pagination, Navigation } from 'swiper/modules'
 
 import { testimonials } from '~/utils/constant/testimonials'
-import SectionTitle from '~/components/molecules/section-title'
-import TestimonialCard from '~/components/molecules/testimonial-card'
+import { SectionTitle } from '~/components/molecules/section-title'
+import { TestimonialCard } from '~/components/molecules/testimonial-card'
 
-const TestimonialSection: FC<Record<string, unknown>> = (): JSX.Element => {
+export default function TestimonialSection(): JSX.Element {
   return (
     <section id="testimonial" className="section-block transition-colors duration-700">
       <div className="section">
@@ -38,5 +38,3 @@ const TestimonialSection: FC<Record<string, unknown>> = (): JSX.Element => {
     </section>
   )
 }
-
-export default TestimonialSection

--- a/frontend/src/components/templates/theme-provider/index.tsx
+++ b/frontend/src/components/templates/theme-provider/index.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react'
+import React from 'react'
 import { type ThemeProviderProps } from 'next-themes/dist/types'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 
-export const ThemeProvider: FC<ThemeProviderProps> = ({ children, ...props }): JSX.Element => {
+export const ThemeProvider = ({ children, ...props }: ThemeProviderProps): JSX.Element => {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import Aos from 'aos'
+import React, { useEffect } from 'react'
 import type { AppProps } from 'next/app'
 import { Toaster } from 'react-hot-toast'
-import React, { FC, useEffect } from 'react'
 // @ts-expect-error: Temporary workaround for missing types in 'react-messenger-customer-chat' library
 import MessengerCustomerChat from 'react-messenger-customer-chat'
 
@@ -9,7 +9,7 @@ import '~/styles/globals.css'
 import { openSans } from '~/utils/font'
 import { ThemeProvider } from '~/components/templates/theme-provider'
 
-const MyApp: FC<AppProps> = ({ Component, pageProps }): JSX.Element => {
+export default function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   useEffect(() => {
     Aos.init({
       duration: 1800,
@@ -32,5 +32,3 @@ const MyApp: FC<AppProps> = ({ Component, pageProps }): JSX.Element => {
     </div>
   )
 }
-
-export default MyApp

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Html, Head, Main, NextScript } from 'next/document'
 
-const Document = (): JSX.Element => {
+export default function Document(): JSX.Element {
   return (
     <Html className="scroll-smooth" lang="en">
       <Head>
@@ -16,5 +16,3 @@ const Document = (): JSX.Element => {
     </Html>
   )
 }
-
-export default Document

--- a/frontend/src/pages/blog/[slug].tsx
+++ b/frontend/src/pages/blog/[slug].tsx
@@ -2,20 +2,20 @@ import fs from 'fs'
 import matter from 'gray-matter'
 import { ParsedUrlQuery } from 'querystring'
 import React, { useEffect, useState } from 'react'
-import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
+import { GetStaticPaths, GetStaticProps } from 'next'
 
 import { FrontMatter } from '~/utils/types'
+import MarkdownRender from '~/lib/markdown-render'
 import calculateReadTime from '~/utils/readTimeDuration'
 import BlogLayout from '~/components/templates/blog-layout'
-import MarkdownRender from '~/lib/markdown-render'
 
-type Props = {
+type BlogProps = {
   frontMatter: FrontMatter
   content: string
   readTime: number
 }
 
-const Blog: NextPage<Props> = ({ frontMatter, content, readTime }): JSX.Element => {
+export default function Blog({ frontMatter, content, readTime }: BlogProps): JSX.Element {
   const [renderedContent, setRenderedContent] = useState<string>('')
 
   useEffect(() => {
@@ -67,5 +67,3 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     }
   }
 }
-
-export default Blog

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -2,11 +2,11 @@ import fs from 'fs'
 import React from 'react'
 import matter from 'gray-matter'
 import dynamic from 'next/dynamic'
-import type { GetStaticProps, NextPage } from 'next'
+import type { GetStaticProps } from 'next'
 
 import { Blog } from '~/utils/types'
 import Layout from '~/components/templates/layout'
-import Footer from '~/components/organisms/footer'
+import { Footer } from '~/components/organisms/footer'
 import { Separator } from '~/components/atoms/separator'
 import HeroSection from '~/components/templates/hero-section'
 import SocialLinkSection from '~/components/templates/social-link-section'
@@ -45,11 +45,11 @@ const ContactSection = dynamic(async () => await import('~/components/templates/
   ssr: false
 })
 
-type Props = {
+type IndexProps = {
   posts: Blog[]
 }
 
-const Index: NextPage<Props> = ({ posts }): JSX.Element => {
+export default function Index({ posts }: IndexProps): JSX.Element {
   return (
     <Layout>
       <HeroSection />
@@ -94,5 +94,3 @@ export const getStaticProps: GetStaticProps = () => {
     }
   }
 }
-
-export default Index

--- a/frontend/src/utils/icons/BubbleCircleIcon.tsx
+++ b/frontend/src/utils/icons/BubbleCircleIcon.tsx
@@ -1,8 +1,6 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { ComponentProps } from 'react'
 
-type Props = ComponentProps<'svg'>
-
-const BubbleCircleIcon: FC<Props> = (props): JSX.Element => {
+export const BubbleCircleIcon = (props: ComponentProps<'svg'>): JSX.Element => {
   return (
     <svg
       width="98"
@@ -35,5 +33,3 @@ const BubbleCircleIcon: FC<Props> = (props): JSX.Element => {
     </svg>
   )
 }
-
-export default BubbleCircleIcon

--- a/frontend/src/utils/icons/FigmaIcon.tsx
+++ b/frontend/src/utils/icons/FigmaIcon.tsx
@@ -1,8 +1,6 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { ComponentProps } from 'react'
 
-type Props = ComponentProps<'svg'>
-
-const FigmaIcon: FC<Props> = (props): JSX.Element => {
+export const FigmaIcon = (props: ComponentProps<'svg'>): JSX.Element => {
   return (
     <svg {...props} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <g fill="none" fillRule="evenodd" transform="translate(4)">
@@ -27,5 +25,3 @@ const FigmaIcon: FC<Props> = (props): JSX.Element => {
     </svg>
   )
 }
-
-export default FigmaIcon

--- a/frontend/src/utils/icons/NextJSIcon.tsx
+++ b/frontend/src/utils/icons/NextJSIcon.tsx
@@ -1,8 +1,6 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { ComponentProps } from 'react'
 
-type Props = ComponentProps<'svg'>
-
-const NextJSIcon: FC<Props> = (props): JSX.Element => {
+export const NextJSIcon = (props: ComponentProps<'svg'>): JSX.Element => {
   return (
     <svg
       {...props}
@@ -58,5 +56,3 @@ const NextJSIcon: FC<Props> = (props): JSX.Element => {
     </svg>
   )
 }
-
-export default NextJSIcon

--- a/frontend/src/utils/icons/TailwindcssIcon.tsx
+++ b/frontend/src/utils/icons/TailwindcssIcon.tsx
@@ -1,8 +1,6 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { ComponentProps } from 'react'
 
-type Props = ComponentProps<'svg'>
-
-const TailwindcssIcon: FC<Props> = (props): JSX.Element => {
+export const TailwindcssIcon = (props: ComponentProps<'svg'>): JSX.Element => {
   return (
     <svg
       {...props}
@@ -16,5 +14,3 @@ const TailwindcssIcon: FC<Props> = (props): JSX.Element => {
     </svg>
   )
 }
-
-export default TailwindcssIcon

--- a/frontend/src/utils/icons/TropyIcon.tsx
+++ b/frontend/src/utils/icons/TropyIcon.tsx
@@ -1,8 +1,6 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { ComponentProps } from 'react'
 
-type Props = ComponentProps<'svg'>
-
-const TropyIcon: FC<Props> = (props): JSX.Element => {
+export const TropyIcon = (props: ComponentProps<'svg'>): JSX.Element => {
   return (
     <svg
       {...props}
@@ -25,5 +23,3 @@ const TropyIcon: FC<Props> = (props): JSX.Element => {
     </svg>
   )
 }
-
-export default TropyIcon


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/JG-26-FE-Refactor-Standard-React-Arrow-Function-Component-d77cb58a72024d239125fd252c31411e?pvs=4

## Definition of Done

- [x] Update the arrow based component into Arrow Function

## Notes

- Code refactoring only

## Pre-condition

- cd frontend && yarn dev 

## Expected Output

- It should now have an standard functional component rather than arrow function in the based page/layout component


