### PR TITLE
JG-27 - [FE] Fetch Github Reputation and Display

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,8 @@
     "slick-carousel": "^1.8.1",
     "swiper": "^10.3.1",
     "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",

--- a/frontend/src/components/templates/about-section/index.tsx
+++ b/frontend/src/components/templates/about-section/index.tsx
@@ -24,7 +24,7 @@ export default function AboutSection(): JSX.Element {
           </div>
           <div className="mt-4" data-aos="fade-down" data-aos-delay="700">
             <p className="section-p">
-              I&apos;m Josh, residing in the province of Bato, Leyte. With 2 years of freelancing
+              I&apos;m Josh, residing in the province of Leyte. With 2 years of freelancing
               experience in video editing and 1.4 years of full-time work as a web developer at Sun
               Asterisk Philippines, I possess expertise in Fullstack application development, web
               design, and video editing.

--- a/frontend/src/components/templates/hero-section/figma-icon.tsx
+++ b/frontend/src/components/templates/hero-section/figma-icon.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { cn } from '~/utils/cn'
+import { FigmaIcon as Figma } from '~/utils/icons/FigmaIcon'
+
+export const FigmaIcon = (): JSX.Element => {
+  return (
+    <div
+      className={cn(
+        'absolute bottom-[90px] right-[40px] z-10 rounded-full',
+        'bg-slate-200 p-2.5 shadow-md dark:bg-slate-800',
+        'transition-colors duration-700'
+      )}
+    >
+      <Figma className="h-9 w-9 sm:h-12 sm:w-12" />
+    </div>
+  )
+}

--- a/frontend/src/components/templates/hero-section/index.tsx
+++ b/frontend/src/components/templates/hero-section/index.tsx
@@ -1,19 +1,19 @@
 import Image from 'next/image'
-import CountUp from 'react-countup'
+import { ArrowUp } from 'lucide-react'
 import React, { useState } from 'react'
-import { ArrowUp, Plus } from 'lucide-react'
 
 import { cn } from '~/utils/cn'
 import { TLink } from '~/utils/types'
 import { nunito } from '~/utils/font'
-import { Card } from '~/components/atoms/card'
 import { Button } from '~/components/atoms/button'
-import { TropyIcon } from '~/utils/icons/TropyIcon'
-import { FigmaIcon } from '~/utils/icons/FigmaIcon'
-import { NextJSIcon } from '~/utils/icons/NextJSIcon'
 import { Header } from '~/components/organisms/header'
-import { TailwindcssIcon } from '~/utils/icons/TailwindcssIcon'
 import { BubbleCircleIcon } from '~/utils/icons/BubbleCircleIcon'
+
+import { FigmaIcon } from './figma-icon'
+import { NextJSIcon } from './nextjs-icon'
+import { TailwindIcon } from './tailwind-icon'
+import { StackOverflowCard } from './stackoverflow-card'
+import { ProjectNumberCard } from './project-number-card'
 
 export default function HeroSection(): JSX.Element {
   const [links] = useState<TLink[]>([
@@ -121,105 +121,17 @@ export default function HeroSection(): JSX.Element {
             />
           </div>
           {/* Tailwindcss Icon */}
-          <TailwindIconComp />
+          <TailwindIcon />
           {/* NextJS Icon */}
-          <NextJSIconComp />
+          <NextJSIcon />
           {/* Figma Icon */}
-          <FigmaIconComp />
+          <FigmaIcon />
           {/* Stack Overflow Card */}
-          <StackOverflowCardComp />
+          <StackOverflowCard />
           {/* Number of Projects Card */}
-          <ProjectNumberCardComp />
+          <ProjectNumberCard />
         </div>
       </div>
     </section>
-  )
-}
-
-function TailwindIconComp(): JSX.Element {
-  return (
-    <div
-      className={cn(
-        'absolute bottom-[220px] right-[250px] z-10 rounded-full p-2.5',
-        'shadow-md dark:bg-slate-800 sm:bottom-[220px] sm:right-[470px]',
-        'transition-colors duration-700'
-      )}
-    >
-      <TailwindcssIcon className="h-12 w-12 text-[#38bdf8]" />
-    </div>
-  )
-}
-
-function NextJSIconComp(): JSX.Element {
-  return (
-    <div>
-      <NextJSIcon
-        className={cn(
-          'absolute bottom-[250px] right-[30px] z-10 h-20',
-          'w-20 scale-75 text-black sm:right-[80px] sm:scale-100'
-        )}
-      />
-    </div>
-  )
-}
-
-function FigmaIconComp(): JSX.Element {
-  return (
-    <div
-      className={cn(
-        'absolute bottom-[90px] right-[40px] z-10 rounded-full',
-        'bg-slate-200 p-2.5 shadow-md dark:bg-slate-800',
-        'transition-colors duration-700'
-      )}
-    >
-      <FigmaIcon className="h-9 w-9 sm:h-12 sm:w-12" />
-    </div>
-  )
-}
-
-function StackOverflowCardComp(): JSX.Element {
-  return (
-    <div className="absolute right-0 z-10">
-      <Card
-        className={cn(
-          'relative w-full max-w-[240px] border border-slate-200 backdrop-blur-xl',
-          'bg-[#FDFDFD]/50 blur-none hover:bg-[#FDFDFD]/80 dark:border-slate-700',
-          'transition-colors duration-700 dark:bg-slate-900/50 hover:dark:bg-slate-900/80'
-        )}
-      >
-        <div className="px-6 py-3">
-          <TropyIcon className="h-8 w-8 sm:h-14 sm:w-14" />
-          <p className="pt-1 text-sm font-bold text-slate-800 dark:text-slate-300 sm:text-base">
-            <CountUp start={1} end={1149} duration={4} enableScrollSpy />+ Stack Overflow Reputation
-          </p>
-        </div>
-      </Card>
-    </div>
-  )
-}
-
-function ProjectNumberCardComp(): JSX.Element {
-  return (
-    <div className="absolute right-[350px] z-10 sm:right-[400px]">
-      <Card
-        className={cn(
-          'relative w-full max-w-[240px] border border-slate-200 backdrop-blur-xl',
-          'bg-[#FDFDFD]/50 blur-none hover:bg-[#FDFDFD]/80 dark:border-slate-700',
-          'transition-colors duration-700 dark:bg-slate-900/50 hover:dark:bg-slate-900/80'
-        )}
-      >
-        <div className="px-6 py-3">
-          <div className="relative flex items-start text-indigo-500">
-            <h2 className="text-xl font-bold sm:text-3xl">
-              <CountUp start={1} end={25} duration={6} enableScrollSpy />
-            </h2>
-            <Plus size={14} strokeWidth="5" />
-          </div>
-          <p className="pt-1 text-sm font-bold text-slate-800 dark:text-slate-300 sm:text-base">
-            Completed Projects
-          </p>
-        </div>
-      </Card>
-    </div>
   )
 }

--- a/frontend/src/components/templates/hero-section/nextjs-icon.tsx
+++ b/frontend/src/components/templates/hero-section/nextjs-icon.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { cn } from '~/utils/cn'
+import { NextJSIcon as NextJS } from '~/utils/icons/NextJSIcon'
+
+export const NextJSIcon = (): JSX.Element => {
+  return (
+    <div>
+      <NextJS
+        className={cn(
+          'absolute bottom-[250px] right-[30px] z-10 h-20',
+          'w-20 scale-75 text-black sm:right-[80px] sm:scale-100'
+        )}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/templates/hero-section/project-number-card.tsx
+++ b/frontend/src/components/templates/hero-section/project-number-card.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Plus } from 'lucide-react'
+import CountUp from 'react-countup'
+
+import { cn } from '~/utils/cn'
+import { Card } from '~/components/atoms/card'
+
+export const ProjectNumberCard = (): JSX.Element => {
+  return (
+    <div className="absolute right-[350px] z-10 sm:right-[400px]">
+      <Card
+        className={cn(
+          'relative w-full max-w-[240px] border border-slate-200 backdrop-blur-xl',
+          'bg-[#FDFDFD]/50 blur-none hover:bg-[#FDFDFD]/80 dark:border-slate-700',
+          'transition-colors duration-700 dark:bg-slate-900/50 hover:dark:bg-slate-900/80'
+        )}
+      >
+        <div className="px-6 py-3">
+          <div className="relative flex items-start text-indigo-500">
+            <h2 className="text-xl font-bold sm:text-3xl">
+              <CountUp start={1} end={25} duration={6} enableScrollSpy />
+            </h2>
+            <Plus size={14} strokeWidth="5" />
+          </div>
+          <p className="pt-1 text-sm font-bold text-slate-800 dark:text-slate-300 sm:text-base">
+            Completed Projects
+          </p>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/templates/hero-section/stackoverflow-card.tsx
+++ b/frontend/src/components/templates/hero-section/stackoverflow-card.tsx
@@ -1,0 +1,54 @@
+import CountUp from 'react-countup'
+import React, { useEffect, useState } from 'react'
+
+import { cn } from '~/utils/cn'
+import { Card } from '~/components/atoms/card'
+import { responseDataSchema } from '~/utils/types'
+import { TropyIcon } from '~/utils/icons/TropyIcon'
+
+export const StackOverflowCard = (): JSX.Element => {
+  const [totalReputation, setTotalReputation] = useState<number>(1)
+
+  const fetchData = async (): Promise<void> => {
+    try {
+      const response = await fetch(
+        'https://api.stackexchange.com/2.3/users/14108225/reputation?site=stackoverflow'
+      )
+      const rawData = await response.json()
+
+      // Validate the response data against the schema
+      const parsedData = responseDataSchema.parse(rawData)
+
+      // Calculate the total reputation
+      const total = parsedData.items.reduce((sum, item) => sum + item.reputation_change, 0)
+
+      setTotalReputation(total)
+    } catch {
+      throw new Error('Something went wrong')
+    }
+  }
+
+  useEffect(() => {
+    void fetchData()
+  }, [])
+
+  return (
+    <div className="absolute right-0 z-10">
+      <Card
+        className={cn(
+          'relative w-full max-w-[240px] border border-slate-200 backdrop-blur-xl',
+          'bg-[#FDFDFD]/50 blur-none hover:bg-[#FDFDFD]/80 dark:border-slate-700',
+          'transition-colors duration-700 dark:bg-slate-900/50 hover:dark:bg-slate-900/80'
+        )}
+      >
+        <div className="px-6 py-3">
+          <TropyIcon className="h-8 w-8 sm:h-14 sm:w-14" />
+          <p className="pt-1 text-sm font-bold text-slate-800 dark:text-slate-300 sm:text-base">
+            <CountUp start={1} end={totalReputation} duration={4} enableScrollSpy />+ Stack Overflow
+            Reputation
+          </p>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/components/templates/hero-section/tailwind-icon.tsx
+++ b/frontend/src/components/templates/hero-section/tailwind-icon.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { cn } from '~/utils/cn'
+import { TailwindcssIcon } from '~/utils/icons/TailwindcssIcon'
+
+export const TailwindIcon = (): JSX.Element => {
+  return (
+    <div
+      className={cn(
+        'absolute bottom-[220px] right-[250px] z-10 rounded-full p-2.5',
+        'shadow-md dark:bg-slate-800 sm:bottom-[220px] sm:right-[470px]',
+        'transition-colors duration-700'
+      )}
+    >
+      <TailwindcssIcon className="h-12 w-12 text-[#38bdf8]" />
+    </div>
+  )
+}

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 export type Blog = {
   slug: string
   frontMatter: FrontMatter
@@ -17,3 +19,22 @@ export type TLink = {
   href: string
   offset: number
 }
+
+// Define a schema using Zod
+export const reputationChangeSchema = z.object({
+  on_date: z.number(),
+  reputation_change: z.number(),
+  vote_type: z.string(),
+  post_type: z.string(),
+  post_id: z.number(),
+  user_id: z.number()
+})
+
+export const responseDataSchema = z.object({
+  items: z.array(reputationChangeSchema),
+  has_more: z.boolean(),
+  quota_max: z.number(),
+  quota_remaining: z.number()
+})
+
+export type ResponseData = z.infer<typeof responseDataSchema>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4268,3 +4268,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
## Issue Link

- https://www.notion.so/JG-28-FE-Fetch-Github-Reputation-and-Display-3ad96cc24e7140f1836ac2c5131c857b?pvs=4

## Definition of Done

- [x] Update the reputation with actual reputation in stackoverflow reputation 
- [x] Refactor Code and Separate Custom Icon  

## Notes

- Frontend only

## Pre-condition

 - cd frontend && yarn dev 

## Expected Output

- It should now have an actual data for stackvoverflow reputation

![image](https://github.com/jsvelte/joshuagalit.com/assets/38458781/99ca1cfe-7abd-4fc1-996a-0d0e8af99b92)


Title
Image/Picture
